### PR TITLE
[STC-12] workflows/gradle.yml 파일 브랜치명 (기존)master -> (변경)main 수정

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -2,9 +2,9 @@ name: Java CI with Gradle
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main" ]
 
 permissions:
   contents: read


### PR DESCRIPTION
기존 workflows/gradle.yml 코드 중 브랜치명이 master로 잘못 작성되어 main으로 수정하였습니다.